### PR TITLE
fix(ui): guard history data shape

### DIFF
--- a/client/src/components/FeelingtHistoryComponent.js
+++ b/client/src/components/FeelingtHistoryComponent.js
@@ -21,10 +21,10 @@ const activityMeta = {
 const FeelingHistoryComponent = ({data = [], isFetching}) => {
   const [commentRowToggle, setCommentRowToggle] = useState(null);
 
-  const sortedFeelings = useMemo(
-    () => [...data].sort((a, b) => (new Date(b.createdAt) - new Date(a.createdAt))),
-    [data]
-  );
+  const sortedFeelings = useMemo(() => {
+    const normalizedData = Array.isArray(data) ? data : [];
+    return [...normalizedData].sort((a, b) => (new Date(b.createdAt) - new Date(a.createdAt)));
+  }, [data]);
 
   const toggle = (id) => {
     if (commentRowToggle === id) {

--- a/client/src/components/WithFetch.js
+++ b/client/src/components/WithFetch.js
@@ -6,7 +6,7 @@ import config from "../config";
 
 const WithFetch = (props) => {
   const { user, getAccessTokenSilently } = useAuth0();
-  const [data, setData] = useState({});
+  const [data, setData] = useState([]);
   const [isFetching, setIsFetching] = useState(true);
 
   const fetch = async () => {


### PR DESCRIPTION
##Summary

Fix a crash in the history view caused by assuming fetched data is always iterable.

## Changes

- initialize fetched history data as an empty array
- guard the history component against non-array data

## Validation

- `npm run build` in `client/`