### PR TITLE
fix(deploy): prepare app for Heroku container stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
 # Build the Go API
-FROM golang:latest AS builder
-ADD . /app
+FROM golang:1.22 AS go_builder
+WORKDIR /app
+COPY server/go.mod server/go.sum ./server/
 WORKDIR /app/server
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w" -a -o /main .
+COPY server/ ./
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-w -s" -o /main .
 
 # Build the React application
-FROM node:16.14.0-alpine3.15 AS node_builder
-COPY --from=builder /app/client ./
+FROM node:20-alpine AS node_builder
+WORKDIR /app/client
+COPY client/package*.json ./
 RUN npm install
+COPY client/ ./
 RUN npm run build
 
-# Final stage build, this will be the container
-# that we will deploy to production
-FROM alpine:latest
+# Final runtime image
+FROM alpine:3.20
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /main ./
-COPY --from=node_builder /build ./web
+WORKDIR /app
+COPY --from=go_builder /main ./main
+COPY --from=node_builder /app/client/build ./web
 RUN chmod +x ./main
 EXPOSE 8080
-CMD ./main
+ENV PORT=8080
+CMD ["./main"]

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "name": "feeling",
+  "description": "Mood tracking app with Go backend and React frontend",
+  "stack": "container"
+}

--- a/server/main.go
+++ b/server/main.go
@@ -172,7 +172,12 @@ func main() {
 	r.GET("/api/feelings", checkJWT(), GetFeelingsHandler(dbClient))
 	r.POST("/api/feelings", checkJWT(), PostFeelingHandler(dbClient))
 
-	err := r.Run()
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	err := r.Run(":" + port)
 	if err != nil {
 		log.Fatal("Could not run server", err.Error())
 		return


### PR DESCRIPTION
## Summary

Prepare the app for Heroku container deployment after stack/build detection issues.

## Changes

- add `app.json` with container stack metadata
- update Dockerfile for a cleaner multi-stage production build
- make the Go server bind to Heroku's `PORT` env var

## Validation

- local `docker build` succeeds