### PR TITLE
fix(auth): persist login across refreshes

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -18,6 +18,8 @@ ReactDOM.render(
     clientId={config.CLIENT_ID}
     redirectUri={window.location.origin}
     audience={config.AUD}
+    cacheLocation="localstorage"
+    useRefreshTokens={true}
   >
     <App />
   </Auth0Provider>


### PR DESCRIPTION
## Summary

Persist Auth0 login across page refreshes.

## Changes

- enable localStorage cache for Auth0 tokens
- enable refresh token usage in the Auth0 provider

## Validation

- `npm run build` in `client/`