### PR TITLE
feat(api): add chat feeling ingest endpoints

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -9,31 +9,35 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"log"
+	"net/http"
+	"time"
 )
+
+type ChatFeelingPayload struct {
+	Status     int      `json:"status"`
+	Activities Activity `json:"activities"`
+	Comment    string   `json:"comment"`
+	CreatedAt  string   `json:"createdAt"`
+	Source     string   `json:"source"`
+}
 
 func GetFeelingsHandler(dbClient *mongo.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		collection := dbClient.Database("feeling").Collection("feelings")
-		// Pass these options to the Find method
 		findOptions := options.Find()
 		var results []*Feeling
 
-		// Get the user id from header
 		userID := c.Request.Header.Get("x-user-id")
 
-		// Passing bson.D{{}} as the filter matches all documents in the collection
 		cur, err := collection.Find(context.TODO(), bson.M{"userid": userID}, findOptions)
 		if err != nil {
 			log.Print(err)
 			errorMessage, _ := json.Marshal([]byte(`{message: something went wrong}`))
 			c.JSON(500, errorMessage)
+			return
 		}
 
-		// Finding multiple documents returns a cursor
-		// Iterating through the cursor allows us to decode documents one at a time
 		for cur.Next(context.TODO()) {
-
-			// create a value into which the single document can be decoded
 			var elem Feeling
 			err := cur.Decode(&elem)
 			if err != nil {
@@ -48,9 +52,9 @@ func GetFeelingsHandler(dbClient *mongo.Client) gin.HandlerFunc {
 			log.Print(err)
 			errorMessage, _ := json.Marshal([]byte(`{message: something went wrong}`))
 			c.JSON(500, errorMessage)
+			return
 		}
 
-		// Close the cursor once finished
 		cur.Close(context.TODO())
 		c.JSON(200, results)
 	}
@@ -61,14 +65,13 @@ func PostFeelingHandler(dbClient *mongo.Client) gin.HandlerFunc {
 		var feeling Feeling
 		err := c.BindJSON(&feeling)
 
-		//get user id from header
 		userID := c.Request.Header.Get("x-user-id")
 		feeling.UserID = userID
 
 		if err != nil {
 			log.Println("There was an error inserting feeling {}", err.Error())
 			c.JSON(400, err.Error())
-
+			return
 		}
 
 		fmt.Println(feeling)
@@ -77,9 +80,108 @@ func PostFeelingHandler(dbClient *mongo.Client) gin.HandlerFunc {
 
 		if dbErr != nil {
 			log.Println("There was an error inserting feeling {}", dbErr.Error())
+			c.JSON(500, gin.H{"message": "could not save feeling"})
+			return
 		}
 
 		log.Println("Inserted multiple documents: ", result.InsertedID)
 		c.JSON(200, feeling)
+	}
+}
+
+func GetChatCapabilitiesHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"actions": gin.H{
+				"log_feeling": gin.H{
+					"description": "Save a feeling entry from chat",
+					"fields": gin.H{
+						"status": gin.H{
+							"type":          "integer",
+							"required":      true,
+							"allowedValues": []int{0, 1, 2, 3, 4},
+						},
+						"activities": gin.H{
+							"type":        "object",
+							"required":    false,
+							"allowedKeys": []string{"bow", "run", "lift", "swim", "cycle"},
+						},
+						"comment": gin.H{
+							"type":     "string",
+							"required": false,
+						},
+						"createdAt": gin.H{
+							"type":     "string",
+							"format":   "date-time",
+							"required": false,
+							"default":  "now",
+						},
+					},
+					"examples": []string{
+						"mood 4 run lift feeling great",
+						"status 2 swim tired",
+						"I’m 3 today, did a run, feeling okay",
+					},
+				},
+			},
+		})
+	}
+}
+
+func PostChatFeelingHandler(dbClient *mongo.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var payload ChatFeelingPayload
+		if err := c.BindJSON(&payload); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "invalid request body"})
+			return
+		}
+
+		if payload.Status < 0 || payload.Status > 4 {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "status must be between 0 and 4"})
+			return
+		}
+
+		userID := c.Request.Header.Get("x-user-id")
+		if userID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "missing x-user-id header"})
+			return
+		}
+
+		createdAt := time.Now().UTC()
+		if payload.CreatedAt != "" {
+			parsed, err := time.Parse(time.RFC3339, payload.CreatedAt)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"message": "createdAt must be a valid RFC3339 timestamp"})
+				return
+			}
+			createdAt = parsed
+		}
+
+		feeling := Feeling{
+			Activities: payload.Activities,
+			Status:     fmt.Sprintf("%d", payload.Status),
+			CreatedAt:  createdAt,
+			Comment:    payload.Comment,
+			UserID:     userID,
+		}
+
+		collection := dbClient.Database("feeling").Collection("feelings")
+		result, dbErr := collection.InsertOne(context.TODO(), &feeling)
+		if dbErr != nil {
+			log.Println("There was an error inserting chat feeling {}", dbErr.Error())
+			c.JSON(http.StatusInternalServerError, gin.H{"message": "could not save feeling"})
+			return
+		}
+
+		log.Println("Inserted chat feeling: ", result.InsertedID)
+		c.JSON(http.StatusOK, gin.H{
+			"ok": true,
+			"saved": gin.H{
+				"status":    payload.Status,
+				"createdAt": createdAt,
+				"comment":   payload.Comment,
+				"source":    payload.Source,
+			},
+		})
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -20,9 +20,9 @@ import (
 )
 
 type Activity struct {
-	Bow  	bool `json:"bow"`
-	Lift 	bool `json:"lift"`
-	Run  	bool `json:"run"`
+	Bow   bool `json:"bow"`
+	Lift  bool `json:"lift"`
+	Run   bool `json:"run"`
 	Cycle bool `json:"cycle"`
 	Swim  bool `json:"swim"`
 }
@@ -30,10 +30,10 @@ type Activity struct {
 // Feeling struct
 type Feeling struct {
 	Activities Activity  `json:"activities"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"createdAt"`
-	Comment   string    `json:"comment"`
-	UserID    string    `json:"userID"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"createdAt"`
+	Comment    string    `json:"comment"`
+	UserID     string    `json:"userID"`
 }
 
 type Jwks struct {
@@ -56,23 +56,15 @@ func GetConnectionString() string {
 }
 
 func SetupDB(connectionString string) (*mongo.Client, error) {
-	// Set client options
-	// clientOptions := options.Client().ApplyURI("mongodb://localhost:27017")
 	clientOptions := options.Client().ApplyURI(connectionString)
-
-	// Connect to MongoDB
 	client, err := mongo.Connect(context.TODO(), clientOptions)
 
 	if err != nil {
-		//log.Fatal(err)
 		return nil, err
 	}
 
-	// Check the connection
 	err = client.Ping(context.TODO(), nil)
-
 	if err != nil {
-		//log.Fatal(err)
 		return nil, err
 	}
 
@@ -96,7 +88,7 @@ func getPemCert(token *jwt.Token) (string, error) {
 		return cert, err
 	}
 
-	for k, _ := range jwks.Keys {
+	for k := range jwks.Keys {
 		if token.Header["kid"] == jwks.Keys[k].Kid {
 			cert = "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
 		}
@@ -112,13 +104,12 @@ func getPemCert(token *jwt.Token) (string, error) {
 
 var jwtMiddleware = jwtmiddleware.New(jwtmiddleware.Options{
 	ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-		// Verify 'aud' claim
 		aud := "https://stormy-cliffs-52671.herokuapp.com/api"
 		checkAud := token.Claims.(jwt.MapClaims).VerifyAudience(aud, false)
 		if !checkAud {
 			return token, errors.New("invalid audience")
 		}
-		// Verify 'iss' claim
+
 		iss := "https://dev-vin.au.auth0.com/"
 		checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
 		if !checkIss {
@@ -142,35 +133,58 @@ func checkJWT() gin.HandlerFunc {
 		jwtMid := *jwtMiddleware
 		if err := jwtMid.CheckJWT(c.Writer, c.Request); err != nil {
 			c.AbortWithStatus(401)
+			return
 		}
+		c.Next()
+	}
+}
+
+func checkChatIngestToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		expectedToken := os.Getenv("CHAT_INGEST_TOKEN")
+		providedToken := c.GetHeader("x-ingest-token")
+
+		if expectedToken == "" {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": "chat ingest token is not configured"})
+			return
+		}
+
+		if providedToken == "" || providedToken != expectedToken {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "invalid ingest token"})
+			return
+		}
+
+		c.Next()
 	}
 }
 
 func main() {
-
 	r := gin.Default()
 
 	r.Use(cors.Middleware(cors.Config{
 		Origins:         "*",
 		Methods:         "GET, PUT, POST, DELETE",
-		RequestHeaders:  "Origin, Authorization, Content-Type, x-user-id",
+		RequestHeaders:  "Origin, Authorization, Content-Type, x-user-id, x-ingest-token",
 		ExposedHeaders:  "",
 		MaxAge:          50 * time.Second,
 		Credentials:     true,
 		ValidateHeaders: false,
 	}))
 
-	// Setup and connect to DB
 	conString := GetConnectionString()
 	dbClient, dbErr := SetupDB(conString)
 	if dbErr != nil {
 		log.Fatal(dbErr)
 	}
 
-	// Set routes and handlers
 	r.Use(static.Serve("/", static.LocalFile("./web", true)))
 	r.GET("/api/feelings", checkJWT(), GetFeelingsHandler(dbClient))
 	r.POST("/api/feelings", checkJWT(), PostFeelingHandler(dbClient))
+
+	chat := r.Group("/api/chat")
+	chat.Use(checkChatIngestToken())
+	chat.GET("/capabilities", GetChatCapabilitiesHandler())
+	chat.POST("/feeling", PostChatFeelingHandler(dbClient))
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
## Summary

Add backend endpoints to support logging feeling entries from chat.

## Changes

- add `GET /api/chat/capabilities`
- add `POST /api/chat/feeling`
- protect chat endpoints with `x-ingest-token`
- validate normalized chat payloads before saving
- save chat-ingested entries into the existing feelings collection

## Notes

- requires `CHAT_INGEST_TOKEN` env var
- OpenClaw will parse messages and send normalized payloads

## Validation

- local Docker build succeeds
