### PR TITLE
fix(ui): keep history visible during refresh

### DIFF
--- a/client/src/components/WithFetch.js
+++ b/client/src/components/WithFetch.js
@@ -17,7 +17,7 @@ const WithFetch = (props) => {
     }
 
     try {
-      setIsFetching(true);
+      setIsFetching((previousState) => previousState && data.length === 0);
       const token = await getAccessTokenSilently({
         audience: config.AUD,
       });
@@ -35,7 +35,7 @@ const WithFetch = (props) => {
     } finally {
       setIsFetching(false);
     }
-  }, [getAccessTokenSilently, isAuthenticated, props.url, user]);
+  }, [data.length, getAccessTokenSilently, isAuthenticated, props.url, user]);
 
   useEffect(() => {
     fetchData();


### PR DESCRIPTION
## Summary

Improve polling UX so the current history stays visible while background refreshes run.

## Changes

- only show the loading state on the initial load
- keep existing data visible during polling refreshes
- update the list silently when fresh data arrives

## Validation

- `npm run build` in `client/`