### PR TITLE
feat(api): add agent history endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -57,6 +58,57 @@ func GetFeelingsHandler(dbClient *mongo.Client) gin.HandlerFunc {
 
 		cur.Close(context.TODO())
 		c.JSON(200, results)
+	}
+}
+
+func GetAgentFeelingsHandler(dbClient *mongo.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		collection := dbClient.Database("feeling").Collection("feelings")
+		findOptions := options.Find()
+		findOptions.SetSort(bson.D{{Key: "createdat", Value: -1}})
+
+		if limitParam := c.Query("limit"); limitParam != "" {
+			if limit, err := strconv.ParseInt(limitParam, 10, 64); err == nil && limit > 0 {
+				findOptions.SetLimit(limit)
+			}
+		}
+
+		userID := c.Request.Header.Get("x-user-id")
+		if userID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"message": "missing x-user-id header"})
+			return
+		}
+
+		cur, err := collection.Find(context.TODO(), bson.M{"userid": userID}, findOptions)
+		if err != nil {
+			log.Print(err)
+			c.JSON(http.StatusInternalServerError, gin.H{"message": "could not fetch feelings"})
+			return
+		}
+		defer cur.Close(context.TODO())
+
+		var results []*Feeling
+		for cur.Next(context.TODO()) {
+			var elem Feeling
+			if err := cur.Decode(&elem); err != nil {
+				log.Print("There was an error decoding element")
+				c.JSON(http.StatusInternalServerError, gin.H{"message": "could not decode feelings"})
+				return
+			}
+			results = append(results, &elem)
+		}
+
+		if err := cur.Err(); err != nil {
+			log.Print(err)
+			c.JSON(http.StatusInternalServerError, gin.H{"message": "could not fetch feelings"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"ok":      true,
+			"count":   len(results),
+			"records": results,
+		})
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -158,13 +158,32 @@ func checkChatIngestToken() gin.HandlerFunc {
 	}
 }
 
+func checkAgentToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		expectedToken := os.Getenv("AGENT_API_TOKEN")
+		providedToken := c.GetHeader("x-agent-token")
+
+		if expectedToken == "" {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": "agent api token is not configured"})
+			return
+		}
+
+		if providedToken == "" || providedToken != expectedToken {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "invalid agent token"})
+			return
+		}
+
+		c.Next()
+	}
+}
+
 func main() {
 	r := gin.Default()
 
 	r.Use(cors.Middleware(cors.Config{
 		Origins:         "*",
 		Methods:         "GET, PUT, POST, DELETE",
-		RequestHeaders:  "Origin, Authorization, Content-Type, x-user-id, x-ingest-token",
+		RequestHeaders:  "Origin, Authorization, Content-Type, x-user-id, x-ingest-token, x-agent-token",
 		ExposedHeaders:  "",
 		MaxAge:          50 * time.Second,
 		Credentials:     true,
@@ -185,6 +204,10 @@ func main() {
 	chat.Use(checkChatIngestToken())
 	chat.GET("/capabilities", GetChatCapabilitiesHandler())
 	chat.POST("/feeling", PostChatFeelingHandler(dbClient))
+
+	agent := r.Group("/api/agent")
+	agent.Use(checkAgentToken())
+	agent.GET("/feelings", GetAgentFeelingsHandler(dbClient))
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
## Summary

Add a machine-to-machine endpoint so an agent can retrieve feeling history for analysis.

## Changes

- add `GET /api/agent/feelings`
- protect the endpoint with `x-agent-token`
- require `x-user-id`
- return records newest first
- support optional `limit` query param
- allow `x-agent-token` in CORS headers

## Notes

- requires `AGENT_API_TOKEN` env var

## Validation

- local Docker build succeeds