### PR TITLE
feat(ui): add weekly tracker route

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -331,7 +331,6 @@
   display: none;
 }
 
-.minimal-meta-grid,
 .tracker-top-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -100,6 +100,31 @@
   line-height: 1.6;
 }
 
+.app-nav-tabs {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.app-nav-tab {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(71, 85, 105, 0.42);
+  color: #cbd5e1;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.app-nav-tab-active {
+  background: rgba(251, 191, 36, 0.14);
+  border-color: rgba(251, 191, 36, 0.35);
+  color: #fde68a;
+}
+
 .app-userbar {
   display: flex;
   align-items: center;
@@ -306,9 +331,10 @@
   display: none;
 }
 
-.minimal-meta-grid {
+.minimal-meta-grid,
+.tracker-top-grid {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -337,7 +363,8 @@
   resize: vertical;
 }
 
-.minimal-textarea::placeholder {
+.minimal-textarea::placeholder,
+.minimal-input::placeholder {
   color: #64748b;
 }
 
@@ -504,6 +531,96 @@
 
 .character-empty-state {
   background: rgba(15, 23, 42, 0.35);
+}
+
+.tracker-hero {
+  gap: 18px;
+}
+
+.tracker-head {
+  align-items: center;
+}
+
+.tracker-summary {
+  min-width: 120px;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(71, 85, 105, 0.35);
+}
+
+.tracker-summary-label,
+.tracker-mini-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #94a3b8;
+}
+
+.tracker-summary-value {
+  margin-top: 10px;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.tracker-check-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tracker-check {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(71, 85, 105, 0.38);
+  background: rgba(15, 23, 42, 0.65);
+  color: #cbd5e1;
+  text-align: left;
+}
+
+.tracker-check-active {
+  border-color: rgba(251, 191, 36, 0.35);
+  background: rgba(154, 52, 18, 0.16);
+  color: #fde68a;
+}
+
+.tracker-check-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 8px;
+  border: 1px solid currentColor;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.tracker-notes-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.tracker-mini-card {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid rgba(71, 85, 105, 0.34);
+}
+
+.tracker-text-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.tracker-textarea {
+  min-height: 120px;
 }
 
 .minimal-selected-mood {
@@ -675,7 +792,11 @@
 
   .minimal-mood-grid,
   .minimal-activity-grid,
-  .minimal-meta-grid {
+  .minimal-meta-grid,
+  .tracker-top-grid,
+  .tracker-check-grid,
+  .tracker-notes-grid,
+  .tracker-text-grid {
     grid-template-columns: 1fr;
   }
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -338,6 +338,10 @@
   gap: 16px;
 }
 
+.tracker-top-grid-simple {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .minimal-input,
 .minimal-textarea {
   width: 100%;
@@ -570,6 +574,10 @@
   gap: 12px;
 }
 
+.tracker-check-grid-simple {
+  grid-template-columns: 1fr;
+}
+
 .tracker-check {
   display: flex;
   align-items: center;
@@ -619,8 +627,20 @@
   gap: 18px;
 }
 
+.tracker-text-grid-simple {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .tracker-textarea {
   min-height: 120px;
+}
+
+.tracker-textarea-simple {
+  min-height: 110px;
+}
+
+.tracker-full-width {
+  grid-column: 1 / -1;
 }
 
 .minimal-selected-mood {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './App.css';
 import TitleComponent from './components/TitleComponent';
 import FeelingComponent from './components/FeelingComponent';
+import WeeklyTrackerComponent from './components/WeeklyTrackerComponent';
 import LoginComponent from "./components/LoginComponent";
 import { useAuth0 } from "@auth0/auth0-react";
 import NavBar from "./components/NavBar";
 
+const getViewFromHash = () => {
+  const hash = window.location.hash.replace('#', '');
+  return hash === 'weekly-tracker' ? 'weekly-tracker' : 'feelings';
+};
+
 const App = () => {
   const { isAuthenticated } = useAuth0();
+  const [view, setView] = useState(getViewFromHash());
+
+  useEffect(() => {
+    const syncView = () => setView(getViewFromHash());
+    window.addEventListener('hashchange', syncView);
+    return () => window.removeEventListener('hashchange', syncView);
+  }, []);
+
+  const renderView = () => {
+    if (view === 'weekly-tracker') {
+      return <WeeklyTrackerComponent />;
+    }
+
+    return <FeelingComponent />;
+  };
 
   return (
     <div className="app-shell">
@@ -15,9 +36,9 @@ const App = () => {
       <div className="app-gradient" />
       <div className="app-noise" />
       <div className="app-inner">
-        {isAuthenticated ? <NavBar /> : null}
+        {isAuthenticated ? <NavBar activeView={view} /> : null}
         <main className="app-content">
-          {isAuthenticated ? <FeelingComponent /> : <LoginComponent />}
+          {isAuthenticated ? renderView() : <LoginComponent />}
         </main>
       </div>
     </div>

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import { useAuth0 } from "@auth0/auth0-react";
 
-export default function NavBar() {
+const navItems = [
+  { key: 'feelings', label: 'Journal', href: '#feelings' },
+  { key: 'weekly-tracker', label: 'Weekly tracker', href: '#weekly-tracker' },
+];
+
+export default function NavBar({ activeView = 'feelings' }) {
   const { user, isLoading, logout } = useAuth0();
 
   if (isLoading) {
@@ -14,6 +19,17 @@ export default function NavBar() {
         <div className="app-kicker app-kicker-character">Mood journal</div>
         <h1 className="app-title app-title-character">My.Feelings</h1>
         <p className="app-tagline">A softer way to notice how your days are landing.</p>
+        <nav className="app-nav-tabs" aria-label="Primary">
+          {navItems.map((item) => (
+            <a
+              key={item.key}
+              href={item.href}
+              className={`app-nav-tab ${activeView === item.key ? 'app-nav-tab-active' : ''}`}
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
       </div>
 
       <div className="app-userbar app-userbar-character">

--- a/client/src/components/WeeklyTrackerComponent.js
+++ b/client/src/components/WeeklyTrackerComponent.js
@@ -1,0 +1,219 @@
+import React, { useMemo, useState } from 'react';
+
+const getWeekLabel = () => {
+  const now = new Date();
+  const start = new Date(now);
+  const day = start.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  start.setDate(start.getDate() + diff);
+  return start.toISOString().slice(0, 10);
+};
+
+const checkboxGroups = {
+  body: [
+    'Cardio session 1',
+    'Cardio session 2',
+    'Strength session 1',
+    'Strength session 2',
+    'Mobility / rehab session',
+  ],
+  build: [
+    'Build session 1',
+    'Build session 2',
+  ],
+  bow: [
+    'Archery practice session',
+    'Hunting research / outreach step',
+  ],
+  review: [
+    'Moved enough this week',
+    'Built something real instead of just thinking',
+    'Moved closer to the hunt',
+    'Drifting into overthinking / abstraction',
+  ],
+};
+
+const emptyChecks = Object.fromEntries(
+  Object.entries(checkboxGroups).flatMap(([group, items]) => items.map((item) => [`${group}:${item}`, false]))
+);
+
+const textAreas = [
+  { key: 'bodyNotes', label: 'Body notes', placeholder: 'Energy, pain, recovery, anything worth noting.' },
+  { key: 'buildShipped', label: 'What did I build / test?', placeholder: 'What actually moved forward this week?' },
+  { key: 'buildLearned', label: 'What did I learn?', placeholder: 'Feedback, insight, or signal.' },
+  { key: 'huntProgress', label: 'Bow / hunt progress', placeholder: 'What did I do this week?' },
+  { key: 'energy', label: 'What gave me energy?', placeholder: 'What felt alive, useful, or satisfying?' },
+  { key: 'drain', label: 'What drained me?', placeholder: 'What made the week heavier?' },
+  { key: 'nextAction', label: 'If overthinking showed up, what is the next concrete action?', placeholder: 'One next move only.' },
+  { key: 'theme', label: 'Main theme of the week', placeholder: 'What kind of week was this?' },
+  { key: 'win', label: 'One win', placeholder: 'Something you are actually glad you did.' },
+  { key: 'improve', label: 'One thing to improve next week', placeholder: 'Keep it specific.' },
+  { key: 'focusBody', label: 'Next week: body', placeholder: 'What matters most next week?' },
+  { key: 'focusBuild', label: 'Next week: build', placeholder: 'One clear business/build focus.' },
+  { key: 'focusBow', label: 'Next week: bow / hunt', placeholder: 'One next step.' },
+];
+
+const moodOptions = ['Rough', 'Low', 'Steady', 'Good', 'Great'];
+const huntStatuses = ['Researching', 'Contacted operators', 'Comparing options', 'Ready to book', 'Booked'];
+
+export default function WeeklyTrackerComponent() {
+  const [weekOf, setWeekOf] = useState(getWeekLabel());
+  const [checks, setChecks] = useState(emptyChecks);
+  const [fields, setFields] = useState({
+    bodyNotes: '',
+    buildShipped: '',
+    buildLearned: '',
+    huntProgress: '',
+    energy: '',
+    drain: '',
+    nextAction: '',
+    theme: '',
+    win: '',
+    improve: '',
+    focusBody: '',
+    focusBuild: '',
+    focusBow: '',
+    mood: 'Steady',
+    huntStatus: 'Researching',
+  });
+
+  const completion = useMemo(() => {
+    const total = Object.keys(checks).length;
+    const done = Object.values(checks).filter(Boolean).length;
+    return Math.round((done / total) * 100);
+  }, [checks]);
+
+  const toggleCheck = (key) => {
+    setChecks((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const updateField = (key, value) => {
+    setFields((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="minimal-layout character-layout">
+      <section className="minimal-section panel section-card section-card-character tracker-hero">
+        <div className="minimal-section-head tracker-head">
+          <div>
+            <h2 className="section-title section-title-character">Weekly tracker</h2>
+            <p className="section-subtitle section-subtitle-character">
+              A practical check-in for body, build, and bow / hunt. Keep it honest, not perfect.
+            </p>
+          </div>
+          <div className="tracker-summary">
+            <div className="tracker-summary-label">Completion</div>
+            <div className="tracker-summary-value">{completion}%</div>
+          </div>
+        </div>
+
+        <div className="tracker-top-grid">
+          <div>
+            <label className="minimal-label" htmlFor="weekOf">Week of</label>
+            <input
+              id="weekOf"
+              type="date"
+              className="minimal-input character-input"
+              value={weekOf}
+              onChange={(e) => setWeekOf(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="minimal-label">Week overall felt</label>
+            <select
+              className="minimal-input character-input"
+              value={fields.mood}
+              onChange={(e) => updateField('mood', e.target.value)}
+            >
+              {moodOptions.map((option) => <option key={option}>{option}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="minimal-label">Hunt status</label>
+            <select
+              className="minimal-input character-input"
+              value={fields.huntStatus}
+              onChange={(e) => updateField('huntStatus', e.target.value)}
+            >
+              {huntStatuses.map((option) => <option key={option}>{option}</option>)}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {Object.entries(checkboxGroups).map(([group, items]) => (
+        <section key={group} className="minimal-section panel section-card section-card-character">
+          <div className="minimal-section-head">
+            <div>
+              <h2 className="section-title section-title-character">{group === 'body' ? 'Body' : group === 'build' ? 'Build' : group === 'bow' ? 'Bow / hunt' : 'Weekly review'}</h2>
+            </div>
+          </div>
+
+          <div className="tracker-check-grid">
+            {items.map((item) => {
+              const key = `${group}:${item}`;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className={`tracker-check ${checks[key] ? 'tracker-check-active' : ''}`}
+                  onClick={() => toggleCheck(key)}
+                >
+                  <span className="tracker-check-box">{checks[key] ? '✓' : ''}</span>
+                  <span>{item}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {group === 'body' && (
+            <div className="tracker-notes-grid">
+              <div className="tracker-mini-card">
+                <div className="tracker-mini-label">Energy</div>
+                <input
+                  className="minimal-input character-input"
+                  placeholder="__/10"
+                  value={fields.energyScore || ''}
+                  onChange={(e) => updateField('energyScore', e.target.value)}
+                />
+              </div>
+              <div className="tracker-mini-card">
+                <div className="tracker-mini-label">Body feels</div>
+                <input
+                  className="minimal-input character-input"
+                  placeholder="Strong, sore, flat..."
+                  value={fields.bodyFeels || ''}
+                  onChange={(e) => updateField('bodyFeels', e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+        </section>
+      ))}
+
+      <section className="minimal-section panel section-card section-card-character">
+        <div className="minimal-section-head">
+          <div>
+            <h2 className="section-title section-title-character">Notes</h2>
+            <p className="section-subtitle section-subtitle-character">Keep the writing short and useful.</p>
+          </div>
+        </div>
+
+        <div className="tracker-text-grid">
+          {textAreas.map((field) => (
+            <div key={field.key}>
+              <label className="minimal-label" htmlFor={field.key}>{field.label}</label>
+              <textarea
+                id={field.key}
+                className="minimal-textarea character-input tracker-textarea"
+                placeholder={field.placeholder}
+                value={fields[field.key]}
+                onChange={(e) => updateField(field.key, e.target.value)}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/client/src/components/WeeklyTrackerComponent.js
+++ b/client/src/components/WeeklyTrackerComponent.js
@@ -9,76 +9,31 @@ const getWeekLabel = () => {
   return start.toISOString().slice(0, 10);
 };
 
-const checkboxGroups = {
-  body: [
-    'Cardio session 1',
-    'Cardio session 2',
-    'Strength session 1',
-    'Strength session 2',
-    'Mobility / rehab session',
-  ],
-  build: [
-    'Build session 1',
-    'Build session 2',
-  ],
-  bow: [
-    'Archery practice session',
-    'Hunting research / outreach step',
-  ],
-  review: [
-    'Moved enough this week',
-    'Built something real instead of just thinking',
-    'Moved closer to the hunt',
-    'Drifting into overthinking / abstraction',
-  ],
-};
-
-const emptyChecks = Object.fromEntries(
-  Object.entries(checkboxGroups).flatMap(([group, items]) => items.map((item) => [`${group}:${item}`, false]))
-);
-
-const textAreas = [
-  { key: 'bodyNotes', label: 'Body notes', placeholder: 'Energy, pain, recovery, anything worth noting.' },
-  { key: 'buildShipped', label: 'What did I build / test?', placeholder: 'What actually moved forward this week?' },
-  { key: 'buildLearned', label: 'What did I learn?', placeholder: 'Feedback, insight, or signal.' },
-  { key: 'huntProgress', label: 'Bow / hunt progress', placeholder: 'What did I do this week?' },
-  { key: 'energy', label: 'What gave me energy?', placeholder: 'What felt alive, useful, or satisfying?' },
-  { key: 'drain', label: 'What drained me?', placeholder: 'What made the week heavier?' },
-  { key: 'nextAction', label: 'If overthinking showed up, what is the next concrete action?', placeholder: 'One next move only.' },
-  { key: 'theme', label: 'Main theme of the week', placeholder: 'What kind of week was this?' },
-  { key: 'win', label: 'One win', placeholder: 'Something you are actually glad you did.' },
-  { key: 'improve', label: 'One thing to improve next week', placeholder: 'Keep it specific.' },
-  { key: 'focusBody', label: 'Next week: body', placeholder: 'What matters most next week?' },
-  { key: 'focusBuild', label: 'Next week: build', placeholder: 'One clear business/build focus.' },
-  { key: 'focusBow', label: 'Next week: bow / hunt', placeholder: 'One next step.' },
+const checklist = [
+  '2 cardio sessions',
+  '2 strength sessions',
+  '1 mobility / rehab session',
+  '2 build sessions',
+  '1 archery session',
+  '1 hunt step',
 ];
 
 const moodOptions = ['Rough', 'Low', 'Steady', 'Good', 'Great'];
-const huntStatuses = ['Researching', 'Contacted operators', 'Comparing options', 'Ready to book', 'Booked'];
 
 export default function WeeklyTrackerComponent() {
   const [weekOf, setWeekOf] = useState(getWeekLabel());
-  const [checks, setChecks] = useState(emptyChecks);
+  const [mood, setMood] = useState('Steady');
+  const [checks, setChecks] = useState(
+    Object.fromEntries(checklist.map((item) => [item, false]))
+  );
   const [fields, setFields] = useState({
-    bodyNotes: '',
-    buildShipped: '',
-    buildLearned: '',
-    huntProgress: '',
-    energy: '',
-    drain: '',
-    nextAction: '',
-    theme: '',
     win: '',
-    improve: '',
-    focusBody: '',
-    focusBuild: '',
-    focusBow: '',
-    mood: 'Steady',
-    huntStatus: 'Researching',
+    challenge: '',
+    nextWeek: '',
   });
 
   const completion = useMemo(() => {
-    const total = Object.keys(checks).length;
+    const total = checklist.length;
     const done = Object.values(checks).filter(Boolean).length;
     return Math.round((done / total) * 100);
   }, [checks]);
@@ -98,7 +53,7 @@ export default function WeeklyTrackerComponent() {
           <div>
             <h2 className="section-title section-title-character">Weekly tracker</h2>
             <p className="section-subtitle section-subtitle-character">
-              A practical check-in for body, build, and bow / hunt. Keep it honest, not perfect.
+              A quick weekly reset for body, build, and bow / hunt.
             </p>
           </div>
           <div className="tracker-summary">
@@ -107,7 +62,7 @@ export default function WeeklyTrackerComponent() {
           </div>
         </div>
 
-        <div className="tracker-top-grid">
+        <div className="tracker-top-grid tracker-top-grid-simple">
           <div>
             <label className="minimal-label" htmlFor="weekOf">Week of</label>
             <input
@@ -122,96 +77,79 @@ export default function WeeklyTrackerComponent() {
             <label className="minimal-label">Week overall felt</label>
             <select
               className="minimal-input character-input"
-              value={fields.mood}
-              onChange={(e) => updateField('mood', e.target.value)}
+              value={mood}
+              onChange={(e) => setMood(e.target.value)}
             >
               {moodOptions.map((option) => <option key={option}>{option}</option>)}
-            </select>
-          </div>
-          <div>
-            <label className="minimal-label">Hunt status</label>
-            <select
-              className="minimal-input character-input"
-              value={fields.huntStatus}
-              onChange={(e) => updateField('huntStatus', e.target.value)}
-            >
-              {huntStatuses.map((option) => <option key={option}>{option}</option>)}
             </select>
           </div>
         </div>
       </section>
 
-      {Object.entries(checkboxGroups).map(([group, items]) => (
-        <section key={group} className="minimal-section panel section-card section-card-character">
-          <div className="minimal-section-head">
-            <div>
-              <h2 className="section-title section-title-character">{group === 'body' ? 'Body' : group === 'build' ? 'Build' : group === 'bow' ? 'Bow / hunt' : 'Weekly review'}</h2>
-            </div>
+      <section className="minimal-section panel section-card section-card-character">
+        <div className="minimal-section-head">
+          <div>
+            <h2 className="section-title section-title-character">Weekly checklist</h2>
+            <p className="section-subtitle section-subtitle-character">Hit the basics. Don’t overthink it.</p>
           </div>
+        </div>
 
-          <div className="tracker-check-grid">
-            {items.map((item) => {
-              const key = `${group}:${item}`;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  className={`tracker-check ${checks[key] ? 'tracker-check-active' : ''}`}
-                  onClick={() => toggleCheck(key)}
-                >
-                  <span className="tracker-check-box">{checks[key] ? '✓' : ''}</span>
-                  <span>{item}</span>
-                </button>
-              );
-            })}
-          </div>
-
-          {group === 'body' && (
-            <div className="tracker-notes-grid">
-              <div className="tracker-mini-card">
-                <div className="tracker-mini-label">Energy</div>
-                <input
-                  className="minimal-input character-input"
-                  placeholder="__/10"
-                  value={fields.energyScore || ''}
-                  onChange={(e) => updateField('energyScore', e.target.value)}
-                />
-              </div>
-              <div className="tracker-mini-card">
-                <div className="tracker-mini-label">Body feels</div>
-                <input
-                  className="minimal-input character-input"
-                  placeholder="Strong, sore, flat..."
-                  value={fields.bodyFeels || ''}
-                  onChange={(e) => updateField('bodyFeels', e.target.value)}
-                />
-              </div>
-            </div>
-          )}
-        </section>
-      ))}
+        <div className="tracker-check-grid tracker-check-grid-simple">
+          {checklist.map((item) => (
+            <button
+              key={item}
+              type="button"
+              className={`tracker-check ${checks[item] ? 'tracker-check-active' : ''}`}
+              onClick={() => toggleCheck(item)}
+            >
+              <span className="tracker-check-box">{checks[item] ? '✓' : ''}</span>
+              <span>{item}</span>
+            </button>
+          ))}
+        </div>
+      </section>
 
       <section className="minimal-section panel section-card section-card-character">
         <div className="minimal-section-head">
           <div>
-            <h2 className="section-title section-title-character">Notes</h2>
-            <p className="section-subtitle section-subtitle-character">Keep the writing short and useful.</p>
+            <h2 className="section-title section-title-character">Short review</h2>
+            <p className="section-subtitle section-subtitle-character">Just enough to make next week better.</p>
           </div>
         </div>
 
-        <div className="tracker-text-grid">
-          {textAreas.map((field) => (
-            <div key={field.key}>
-              <label className="minimal-label" htmlFor={field.key}>{field.label}</label>
-              <textarea
-                id={field.key}
-                className="minimal-textarea character-input tracker-textarea"
-                placeholder={field.placeholder}
-                value={fields[field.key]}
-                onChange={(e) => updateField(field.key, e.target.value)}
-              />
-            </div>
-          ))}
+        <div className="tracker-text-grid tracker-text-grid-simple">
+          <div>
+            <label className="minimal-label" htmlFor="win">One win</label>
+            <textarea
+              id="win"
+              className="minimal-textarea character-input tracker-textarea tracker-textarea-simple"
+              placeholder="What actually went well?"
+              value={fields.win}
+              onChange={(e) => updateField('win', e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="minimal-label" htmlFor="challenge">Main challenge</label>
+            <textarea
+              id="challenge"
+              className="minimal-textarea character-input tracker-textarea tracker-textarea-simple"
+              placeholder="What got in the way?"
+              value={fields.challenge}
+              onChange={(e) => updateField('challenge', e.target.value)}
+            />
+          </div>
+
+          <div className="tracker-full-width">
+            <label className="minimal-label" htmlFor="nextWeek">Next week focus</label>
+            <textarea
+              id="nextWeek"
+              className="minimal-textarea character-input tracker-textarea tracker-textarea-simple"
+              placeholder="What matters most next week?"
+              value={fields.nextWeek}
+              onChange={(e) => updateField('nextWeek', e.target.value)}
+            />
+          </div>
         </div>
       </section>
     </div>

--- a/client/src/components/WithFetch.js
+++ b/client/src/components/WithFetch.js
@@ -5,6 +5,66 @@ import {useAuth0} from "@auth0/auth0-react";
 import config from "../config";
 
 const DEFAULT_POLL_INTERVAL_MS = 15000;
+const CLIENT_DEV_URL = 'http://localhost:3000';
+
+const mockFeelings = [
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '1',
+    createdAt: '2020-12-10T21:26:45.996Z',
+    comment: "Had an argument with Ana, not really feeling good about our relationship. Too much criticism from her.",
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '4',
+    createdAt: '2020-11-18T22:24:07.397Z',
+    comment: 'Hit the gym today feeling pretty good. Had sex yesterday, working in the office',
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '2',
+    createdAt: '2021-04-16T00:17:16.137Z',
+    comment: 'Meh. Not sure what will happen in the next few weeks in my relationship',
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '4',
+    createdAt: '2021-06-22T03:47:05.577Z',
+    comment: 'Feeling really good. Ana and I worked out some issues and we both are happy. Need to ge back to archery',
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '2',
+    createdAt: '2020-11-12T22:56:58.752Z',
+    comment: "There is a problem in the room that we booked for Vic's birthday and it is stressing me out.",
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '3',
+    createdAt: '2021-03-30T23:16:48.133Z',
+    comment: "Back is getting better. I was able to go to the gym yesterday and also didn't eat any sugar yesterday too. ",
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '4',
+    createdAt: '2020-11-16T01:55:37.132Z',
+    comment: 'Exercised a lot this morning, so I have a positive feeling about things. The ANZ interview is stressing me out a bit though.',
+    userID: 'google-oauth2|100122194279033713808',
+  },
+  {
+    activities: { bow: false, lift: false, run: false, cycle: false, swim: false },
+    status: '2',
+    createdAt: '2021-03-02T22:11:49.563Z',
+    comment: 'Not sure why but I am feeling no motivation to get out of bed, hurting my back consistently and not feeling good about myself.',
+    userID: 'google-oauth2|100122194279033713808',
+  },
+];
 
 const WithFetch = (props) => {
   const { user, getAccessTokenSilently, isAuthenticated } = useAuth0();
@@ -31,7 +91,11 @@ const WithFetch = (props) => {
 
       setData(Array.isArray(response.data) ? response.data : []);
     } catch (error) {
-      console.log('Error fetching data', error);
+      if (window.location.origin === CLIENT_DEV_URL) {
+        setData(mockFeelings);
+      } else {
+        console.log('Error fetching data', error);
+      }
     } finally {
       setIsFetching(false);
     }


### PR DESCRIPTION
 a new Weekly tracker screen
• lightweight route switching via URL hash
• nav tabs in the header:
  • #feelings
  • #weekly-tracker
• a tracker UI based on the 90-day plan:
  • body
  • build
  • bow / hunt
  • weekly review
  • notes / next-week focus

Build status:

• builds successfully