### PR TITLE
Fix mood history chart ordering and axes

### DIFF
--- a/client/src/components/FeelingChartComponent.js
+++ b/client/src/components/FeelingChartComponent.js
@@ -1,49 +1,89 @@
-import React from 'react'
-import { AxisOptions, Chart } from "react-charts";
+import React, { useMemo } from 'react'
+import moment from 'moment'
+import { Chart } from 'react-charts'
 
-export default function MyChart({feelingHistory}) {
-  const preparedData = () => {
-    return feelingHistory.map((e) => (
-      {
-        status: Number.parseInt(e.status),
-        date: new Date(e.createdAt),
+const clampMood = (value) => {
+  if (!Number.isFinite(value)) {
+    return null
+  }
+  return Math.min(4, Math.max(0, value))
+}
+
+const parseEntryDate = (raw) => {
+  const parsed = raw instanceof Date ? raw : new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export default function FeelingChartComponent({ feelingHistory }) {
+  const chartSeries = useMemo(() => {
+    const rows = Array.isArray(feelingHistory) ? feelingHistory : []
+    const points = []
+
+    for (const entry of rows) {
+      const date = parseEntryDate(entry.createdAt)
+      if (!date) {
+        continue
       }
-    ))
+      const status = clampMood(Number.parseInt(entry.status, 10))
+      if (status === null) {
+        continue
+      }
+      points.push({ date, status })
+    }
+
+    points.sort((a, b) => a.date - b.date)
+
+    return [
+      {
+        label: 'Mood',
+        data: points,
+      },
+    ]
+  }, [feelingHistory])
+
+  const primaryAxis = useMemo(
+    () => ({
+      scaleType: 'localTime',
+      getValue: (datum) => datum.date,
+      formatters: {
+        scale: (value) => moment(value).format('MMM D'),
+        tooltip: (value) => moment(value).format('lll'),
+      },
+    }),
+    []
+  )
+
+  const secondaryAxes = useMemo(
+    () => [
+      {
+        scaleType: 'linear',
+        getValue: (datum) => datum.status,
+        elementType: 'line',
+        min: 0,
+        max: 4,
+        tickCount: 5,
+        formatters: {
+          scale: (value) => value.toFixed(0),
+          tooltip: (value) => value.toFixed(0),
+        },
+      },
+    ],
+    []
+  )
+
+  if (!chartSeries[0].data.length) {
+    return null
   }
 
-  const data = [
-      {
-        label: 'Report',
-        data: preparedData()
-      }
-    ]
-
-  const primaryAxis = React.useMemo(
-    () => ({
-    getValue: datum => datum.date,
-  }),
-    []
-)
-
-  const secondaryAxes = React.useMemo(
-    () => [
-    {
-      getValue: datum => datum.status,
-      elementType: 'line',
-    },
-  ],
-    []
-)
-
- return (
+  return (
     <div
       style={{
-        height: '300px'
+        height: '300px',
       }}
     >
       <Chart
         options={{
-          data,
+          data: chartSeries,
           primaryAxis,
           secondaryAxes,
         }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The History and trends line chart connected points in API return order instead of chronological order, which produced misleading horizontal segments and sharp vertical jumps when newer and older entries were interleaved.

## Changes

- Sort mood entries by `createdAt` before passing them to `react-charts`.
- Use a `localTime` primary axis with human-readable date labels (and clearer tooltips).
- Pin the vertical axis to the valid mood range (0–4) with integer tick labels.
- Skip invalid dates or non-numeric status values so the line is not distorted by bad data.

## Testing

- `CI=true npm test -- --watchAll=false` (client)
- `npm run build` (client)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff882916-3ce9-4f60-b146-ceaa039c8d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff882916-3ce9-4f60-b146-ceaa039c8d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

