### PR TITLE
fix(chart): handle null values in mood axis tooltip formatters

### DIFF
--- a/client/src/components/FeelingChartComponent.js
+++ b/client/src/components/FeelingChartComponent.js
@@ -9,6 +9,15 @@ const clampMood = (value) => {
   return Math.min(4, Math.max(0, value))
 }
 
+/** react-charts may pass null into formatters during tooltip/hover updates */
+const formatAxisNumber = (value) => {
+  if (value == null) {
+    return ''
+  }
+  const n = Number(value)
+  return Number.isFinite(n) ? n.toFixed(0) : ''
+}
+
 const parseEntryDate = (raw) => {
   const parsed = raw instanceof Date ? raw : new Date(raw)
   return Number.isNaN(parsed.getTime()) ? null : parsed
@@ -63,8 +72,8 @@ export default function FeelingChartComponent({ feelingHistory }) {
         max: 4,
         tickCount: 5,
         formatters: {
-          scale: (value) => value.toFixed(0),
-          tooltip: (value) => value.toFixed(0),
+          scale: formatAxisNumber,
+          tooltip: formatAxisNumber,
         },
       },
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The secondary axis `scale` and `tooltip` formatters in `FeelingChartComponent` called `toFixed` on values that `react-charts` sometimes passes as `null` during tooltip/hover updates, which threw `TypeError: Cannot read properties of null (reading 'toFixed')`.

## Changes

- Introduce `formatAxisNumber` that returns an empty string for null/undefined or non-finite numbers, and otherwise formats with `toFixed(0)`.
- Use it for both `scale` and `tooltip` formatters on the mood axis.

## Verification

- `npm run build` in `client/` completed successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5e06f17-f913-4bac-8fbb-91bec8145c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5e06f17-f913-4bac-8fbb-91bec8145c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

