### PR TITLE
Fix mood chart axis labels and invalid date handling

### DIFF
--- a/client/src/components/FeelingChartComponent.js
+++ b/client/src/components/FeelingChartComponent.js
@@ -19,8 +19,20 @@ const formatAxisNumber = (value) => {
 }
 
 const parseEntryDate = (raw) => {
+  if (!raw) {
+    return null
+  }
   const parsed = raw instanceof Date ? raw : new Date(raw)
-  return Number.isNaN(parsed.getTime()) ? null : parsed
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  // Some persisted records use year 0001 as an "empty" value and should not be charted.
+  if (parsed.getUTCFullYear() < 1970) {
+    return null
+  }
+
+  return parsed
 }
 
 export default function FeelingChartComponent({ feelingHistory }) {
@@ -55,7 +67,7 @@ export default function FeelingChartComponent({ feelingHistory }) {
       scaleType: 'localTime',
       getValue: (datum) => datum.date,
       formatters: {
-        scale: (value) => moment(value).format('MMM D'),
+        scale: (value) => moment(value).format('MMM D, YYYY'),
         tooltip: (value) => moment(value).format('lll'),
       },
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- filter out invalid/sentinel mood entries with out-of-range `createdAt` values (e.g. year `0001`) before plotting chart points
- keep mood values clamped to the expected 0-4 range
- format x-axis tick labels with year (`MMM D, YYYY`) so annual ticks no longer render as repeated `Jan 1`

## Why
Mood history responses can include placeholder `createdAt` values (`0001-01-01T00:00:00Z`) that distort the chart time domain and flatten/compress real entries. Also, the prior axis format omitted the year, which made yearly ticks look duplicated.

## Validation
- code inspection of chart data pipeline confirms invalid dates are skipped
- x-axis labels now display full date context including year
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b78b5704-ee6a-4305-86a6-555cee7acc5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b78b5704-ee6a-4305-86a6-555cee7acc5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

